### PR TITLE
Update json property names to reflect PagerDuty api documentation

### DIFF
--- a/src/Events/ContextProperties/Image.cs
+++ b/src/Events/ContextProperties/Image.cs
@@ -1,4 +1,6 @@
-﻿namespace PagerDuty.Events.ContextProperties
+﻿using Newtonsoft.Json;
+
+namespace PagerDuty.Events.ContextProperties
 {
     /// <summary>
     /// This property is used to attach images to the incident.
@@ -8,16 +10,19 @@
         /// <summary>
         /// The source (URL) of the image being attached to the incident. This image must be served via HTTPS.
         /// </summary>
+        [JsonProperty(PropertyName = "src")]
         public string SourceUrl { get; set; }
 
         /// <summary>
         /// Optional URL; makes the image a clickable link.
         /// </summary>
+        [JsonProperty(PropertyName = "href")]
         public string HypertextReference { get; set; }
 
         /// <summary>
         /// Optional alternative text for the image.
         /// </summary>
+        [JsonProperty(PropertyName = "alt")]
         public string AlternativeText { get; set; }
     }
 }

--- a/src/Events/ContextProperties/Link.cs
+++ b/src/Events/ContextProperties/Link.cs
@@ -1,4 +1,6 @@
-﻿namespace PagerDuty.Events.ContextProperties
+﻿using Newtonsoft.Json;
+
+namespace PagerDuty.Events.ContextProperties
 {
     /// <summary>
     /// This property is used to attach text links to the incident.
@@ -8,11 +10,13 @@
         /// <summary>
         /// URL of the link to be attached.
         /// </summary>
+        [JsonProperty(PropertyName = "href")]
         public string HypertextReference { get; set; }
 
         /// <summary>
         /// Plain text that describes the purpose of the link, and can be used as the link's text.
         /// </summary>
+        [JsonProperty(PropertyName = "text")]
         public string Text { get; set; }
     }
 }


### PR DESCRIPTION
With the current implementation, if the optional images/links properties are incorrectly named in the json payload, causing the API to return a 400 error.

This PR resolves this issue by adding the missing JsonProperties to the ContextProperty types.