### PR TITLE
Update Link to match the name in PagerDuty doco

### DIFF
--- a/src/Events/ContextProperties/Link.cs
+++ b/src/Events/ContextProperties/Link.cs
@@ -1,4 +1,6 @@
-﻿namespace PagerDuty.Events.ContextProperties
+using Newtonsoft.Json;
+
+namespace PagerDuty.Events.ContextProperties
 {
     /// <summary>
     /// This property is used to attach text links to the incident.
@@ -8,6 +10,7 @@
         /// <summary>
         /// URL of the link to be attached.
         /// </summary>
+        [PropertyName("href")]
         public string HypertextReference { get; set; }
 
         /// <summary>


### PR DESCRIPTION
It should be "href" instead of HypertextReference according to https://developer.pagerduty.com/docs/events-api-v2/trigger-events/
It would be great to have this update as HypertextReference doesn't work.